### PR TITLE
fixed line endings in _autocomplete.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 demo
 *.egg-info
 dist
+build/

--- a/be/_autocomplete.sh
+++ b/be/_autocomplete.sh
@@ -2,10 +2,10 @@ _be () {
   COMPREPLY=();
 
   local cur=${COMP_WORDS[COMP_CWORD]}
-  
+
   if [ ${COMP_CWORD} -ge 2 ]; then
     if [ ${COMP_WORDS[1]} == "in" ]; then
-      
+
       # Determine whether the last-entered
       # argument is complete. $cur will either
       # be empty, or contain the currently


### PR DESCRIPTION
`be activate` was throwing a syntax error on bash on linux due to Windows line endings in _autocomplete.sh. Re-saving that from a text editor with unix line endings fixed the issue, tested on a local reinstall. Also added the build folder to .gitignore.